### PR TITLE
Add optional authentication

### DIFF
--- a/stash.go
+++ b/stash.go
@@ -258,7 +258,10 @@ func (client Client) GetRepositories() (map[int]Repository, error) {
 			}
 			Log.Printf("stash.GetRepositories URL %s\n", req.URL)
 			req.Header.Set("Accept", "application/json")
-			req.SetBasicAuth(client.userName, client.password)
+			// use credentials if we have them.  If not, the repository must be public.
+			if client.userName != "" && client.password != "" {
+				req.SetBasicAuth(client.userName, client.password)
+			}
 
 			var responseCode int
 			responseCode, data, err = consumeResponse(req)
@@ -411,7 +414,10 @@ func (client Client) GetRepository(projectKey, repositorySlug string) (Repositor
 		}
 		Log.Printf("stash.GetRepository %s\n", req.URL)
 		req.Header.Set("Accept", "application/json")
-		req.SetBasicAuth(client.userName, client.password)
+		// use credentials if we have them.  If not, the repository must be public.
+		if client.userName != "" && client.password != "" {
+			req.SetBasicAuth(client.userName, client.password)
+		}
 
 		responseCode, data, err := consumeResponse(req)
 		if err != nil {


### PR DESCRIPTION
To list repository(ies) , you don't need to be authenticated
That said, the list can be different, whether you are authenticated or not.

I wonder if we should also add this check to all GET methods, since stash seems to let anonymous users do any GET calls (but not POST, you'd get 401)