### PR TITLE
Catch detailed errors

### DIFF
--- a/response_stash_error_test.go
+++ b/response_stash_error_test.go
@@ -1,0 +1,68 @@
+package stash
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const twoErrorsResponse string = `{
+	"errors": [
+		{
+			"context": "name",
+			"message": "The name should be between 1 and 255 characters.",
+			"exceptionName": null
+		},
+		{
+			"context": "email",
+			"message": "The email should be a valid email address.",
+			"exceptionName": null
+		}
+	]
+}`
+
+const invalidJSONResponse string = `{invalid: json}`
+
+func TestStatusGreaterThan400AndTwoErrors(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, twoErrorsResponse)
+	}))
+	defer testServer.Close()
+
+	request, _ := http.NewRequest("GET", testServer.URL, nil)
+	actualStatus, actualBody, actualError := consumeResponse(request)
+	if fmt.Sprint(actualError) != "The name should be between 1 and 255 characters. The email should be a valid email address." {
+		t.Fatalf("Want error with two joined messages, but got '%v'", actualError)
+	}
+	if actualStatus != 400 {
+		t.Fatalf("Want status 400 but found %v", actualStatus)
+	}
+	if string(actualBody) != twoErrorsResponse {
+		t.Fatalf("Want raw response with json but found %v", actualBody)
+	}
+}
+
+func TestStatusLowerThan400AndInvalidJSON(t *testing.T) {
+	// here is occasional case with invalid json response and 200 OK status,
+	// but we should ensure that consumeError doesn't tries to unmarshal
+	// response with 200 status code
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, invalidJSONResponse)
+	}))
+	defer testServer.Close()
+
+	request, _ := http.NewRequest("GET", testServer.URL, nil)
+	actualStatus, actualBody, actualError := consumeResponse(request)
+	if actualError != nil {
+		t.Fatalf("Want error = nil, but got %v", actualError)
+	}
+	if actualStatus != 200 {
+		t.Fatalf("Want status 400 but found %v", actualStatus)
+	}
+	if string(actualBody) != invalidJSONResponse {
+		t.Fatalf("Want raw invalid json response but found %v", string(actualBody))
+	}
+}

--- a/stash.go
+++ b/stash.go
@@ -196,7 +196,7 @@ type (
 	}
 
 	PullRequestResource struct {
-		Version     int    `json:"version,omitempty"`
+		Version     int    `json:"version"`
 		Title       string `json:"title,omitempty"`
 		Description string `json:"description,omitempty"`
 		// FromRef and ToRef should be PullRequestRef but there is interface{}


### PR DESCRIPTION
Hi @ae6rt,

Now users will see more clear error messages, so instead of
```
The repository was not created due to a validation error.
```

they will see more obvious error like as following (example from docs):

```
The name should be between 1 and 255 characters.
```

https://developer.atlassian.com/static/rest/stash/3.11.3/stash-rest.html#errors-and-validation

Also I've fixed bug that has beed added by me in previous pull-request and I'm
sorry for this, UpdatePullRequest() didn't work if pull-request version is
zero (if pull request just created), because json package will think that
(version) parameter has empty value (0) and will omit it.