### PR TITLE
Added more information to "Reviewer"

### DIFF
--- a/stash.go
+++ b/stash.go
@@ -178,7 +178,10 @@ type (
 	}
 
 	Reviewer struct {
-		User User `json:"user"`
+		User     User   `json:"user"`
+		Role     string `json:"role"`
+		Approved bool   `json:"approved"`
+		Status   string `json:"status"`
 	}
 
 	PullRequestProject struct {


### PR DESCRIPTION
Currently the "Reviewer" struct only contains the usernames of the reviewers. But the Stash API also provides the information, if the reviwer approved the PullRequest already.